### PR TITLE
fix: typescript/remove-public-modifier: keep private/protected

### DIFF
--- a/codemods/typescript/remove-public-modifier/src/index.ts
+++ b/codemods/typescript/remove-public-modifier/src/index.ts
@@ -8,7 +8,7 @@ export default function transformer(file: FileInfo, api: API) {
     path.node.body.body.forEach((member) => {
       if (
         (member.type === "ClassMethod" || member.type === "ClassProperty") &&
-        "accessibility" in member
+        "accessibility" in member && member.accessibility === "public"
       ) {
         member.accessibility = undefined;
       }

--- a/codemods/typescript/remove-public-modifier/test/test.ts
+++ b/codemods/typescript/remove-public-modifier/test/test.ts
@@ -73,16 +73,20 @@ describe("remove-public-modifier", () => {
     );
   });
 
-  it("class with other modifiers (static, readonly)", () => {
+  it("class with other modifiers (private, protected, static, readonly)", () => {
     const INPUT = `
 				class MyClass {
 					public static readonly myProperty: string = 'value';
+					private secondProperty: string = 'value';
+					protected thirdProperty: string = 'value';
 				}		  
 			`;
 
     const OUTPUT = `
 				class MyClass {
 					static readonly myProperty: string = 'value';
+					private secondProperty: string = 'value';
+					protected thirdProperty: string = 'value';
 				}	
 			`;
     const fileInfo: FileInfo = {


### PR DESCRIPTION
#### 📚 Description

This is https://github.com/codemod-com/codemod/pull/1414 for the right repository.

Only remove public modifier, keep
any private/protected modifiers.

#### 🔗 Linked Issue

No issue.

#### 🧪 Test Plan

Not sure, I get a lot of failures with `pnpm recursive run test` in the node:20 docker container. 

Test passed in the PR for the other repository.

#### 📄 Documentation to Update

Bug fix, no functional change compared to the documentation.