### PR TITLE
fix(GHA): remove PNPM cache in setup-node action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,7 +28,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "pnpm"
 
       - name: Check prettier
         uses: creyD/prettier_action@v4.3
@@ -70,7 +69,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "pnpm"
+
       - name: Install dependencies
         run: pnpm install -g codemod
 


### PR DESCRIPTION
<!-- THANK YOU for contributing to Codemod Commons! Let's speed up migration velocity for all, one PR at a time! :) Before opening this PR, please: 1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md 2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org Here are some examples: feat(studio): add new codemod engine feat(cli)!: revamp the design (BREAKING CHANGE) fix(cli): fix a bug for the formatter chore(backend): upgrade node docs: improve codemod publish docs refactor(registry www): modularize filters test(vsce): add tests for VS Code extension -->
📚 Description
This PR addresses an issue where the actions/setup-node@v4 step in our GitHub Actions workflow was using the pnpm cache, causing failures due to the absence of a lock file. To resolve this, I have removed the pnpm cache from the setup step to ensure smoother execution.

🔗 Linked Issue
Fixes [#17](https://github.com/codemod-com/commons/issues/17) - CI fails for main branch.

🧪 Test Plan
I tested the changes by running the GitHub Actions workflow. After removing the pnpm cache, the workflow ran successfully without issues.

📄 Documentation to Update
No documentation changes are required as this is a bug fix with no functional changes to the overall system.