### PR TITLE
fix: resolve test failures for codemods missing vitest.config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "prettier": "^3.4.2"
   },
   "devDependencies": {
-    "turbo": "^1.10.14",
     "@codemod-com/tsconfig": "workspace:*",
-    "@codemod-com/utilities": "workspace:*"
+    "@codemod-com/utilities": "workspace:*",
+    "turbo": "^1.10.14",
+    "vitest": "^1.0.1"
   },
   "scripts": {
     "build": "turbo run build",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, "**/test/*.ts", "**/test/*.js"],
+  },
+});


### PR DESCRIPTION
#### 📚 Description

This PR addresses an issue where codemods without a dedicated `vitest.config` file were failing tests. The solution ensures that such codemods default to using the `vitest.config` file from the workspace, preventing unnecessary test failures and improving compatibility.

---

#### 🧪 Test Plan

1. Run tests for codemods without their own `vitest.config` file:  
   ```bash
   pnpm recursive run test
   ```
2. Verify that the workspace `vitest.config` file is used correctly.
3. Confirm all tests pass successfully across affected codemods.
