### PR TITLE
fix(codemods/webpack/v5/json-imports-to-default-imports): correct test fixtures for the codemod 

### DIFF
--- a/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture1.output.ts
+++ b/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture1.output.ts
@@ -1,2 +1,2 @@
-import pkg from "./package.json";
+import pkg from './package.json';
 console.log(pkg.version);

--- a/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture2.output.ts
+++ b/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture2.output.ts
@@ -1,2 +1,2 @@
-import pkg from "./package.json";
+import pkg from './package.json';
 console.log(pkg.version, pkg.name, pkg.description);

--- a/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture3.output.ts
+++ b/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture3.output.ts
@@ -1,2 +1,2 @@
-import pkg from "./data.json";
+import pkg from './data.json';
 console.log(pkg.nested.property, pkg.nested2.property);


### PR DESCRIPTION
#### 📚 Description

This PR fixes issues with the test fixtures for the `webpack/v5/json-imports-to-default-imports` codemod. The previous fixtures had incorrect data, which caused test failures and inconsistent results. This update ensures that the test fixtures are accurate and aligned with the expected codemod behavior.

---

#### 🧪 Test Plan

1. Run all tests using the updated fixtures:  
   ```bash
   npm run test
   ```
2. Confirm all tests pass successfully.
3. Manually verify that the updated fixtures represent the intended transformations.
