### PR TITLE
fix(codemods/webpack/v5/migrate-library-target-to-library-object): correct test fixtures for the codemod

### DIFF
--- a/codemods/webpack/v5/migrate-library-target-to-library-object/__testfixtures__/fixture1.output.ts
+++ b/codemods/webpack/v5/migrate-library-target-to-library-object/__testfixtures__/fixture1.output.ts
@@ -1,8 +1,8 @@
 module.exports = {
   output: {
     library: {
-      name: "MyLibrary",
-      type: "commonjs2",
+      name: 'MyLibrary',
+      type: 'commonjs2',
     },
   },
 };

--- a/codemods/webpack/v5/migrate-library-target-to-library-object/__testfixtures__/fixture2.output.ts
+++ b/codemods/webpack/v5/migrate-library-target-to-library-object/__testfixtures__/fixture2.output.ts
@@ -1,8 +1,8 @@
 module.exports = {
   output: {
     library: {
-      name: "MyLibrary",
-      type: "commonjs2",
+      name: 'MyLibrary',
+      type: 'commonjs2',
     },
 
     filename: "bundle.js",

--- a/codemods/webpack/v5/migrate-library-target-to-library-object/__testfixtures__/fixture3.output.ts
+++ b/codemods/webpack/v5/migrate-library-target-to-library-object/__testfixtures__/fixture3.output.ts
@@ -1,7 +1,7 @@
 module.exports = {
   output: {
     library: {
-      name: "MyLibrary",
+      name: 'MyLibrary',
       type: undefined,
     },
   },

--- a/codemods/webpack/v5/migrate-library-target-to-library-object/__testfixtures__/fixture4.output.ts
+++ b/codemods/webpack/v5/migrate-library-target-to-library-object/__testfixtures__/fixture4.output.ts
@@ -1,8 +1,8 @@
 module.exports = {
   output: {
     library: {
-      name: "MyLibrary",
-      type: "umd",
+      name: 'MyLibrary',
+      type: 'umd',
     },
 
     path: "./dist",


### PR DESCRIPTION
#### 📚 Description

This PR fixes issues with the test fixtures for the `webpack/v5/migrate-library-target-to-library-object` codemod. The previous fixtures had incorrect data, which caused test failures and inconsistent results. This update ensures the test fixtures are accurate and aligned with the expected codemod behavior.

---

#### 🧪 Test Plan

1. Run all tests using the updated fixtures:  
   ```bash
   npm run test
   ```
2. Confirm all tests pass successfully.
3. Manually verify that the updated fixtures represent the intended transformations.
