### PR TITLE
fix: remove test script from package.json in @codemod.com/codemod-utils

### DIFF
--- a/tooling/utilities/package.json
+++ b/tooling/utilities/package.json
@@ -22,7 +22,6 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "test": "vitest run",
     "coverage": "vitest run --coverage"
   },
   "keywords": [],


### PR DESCRIPTION
#### 📚 Description

This PR removes the `test` script from the `package.json` file in the `@codemod.com/codemod-utils` tool. The script was unnecessary, and its removal ensures a cleaner and more accurate package configuration.

---

#### 🧪 Test Plan

1. Verify that the `package.json` file no longer includes the `test` script.  
2. Confirm that all related workflows or processes function as expected without the script.  