### PR TITLE
fix(codemods/react/create-element-to-jsx): correct transform import path in create-element-to-jsx test file

### DIFF
--- a/codemods/react/create-element-to-jsx/test/test.ts
+++ b/codemods/react/create-element-to-jsx/test/test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "vitest";
 import jscodeshift, { type API } from "jscodeshift";
-import transform from "../src/index.cjs";
+import transform from "../src/index.js";
 import assert from "node:assert";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";


### PR DESCRIPTION
#### 📚 Description

This PR fixes an issue with the transform import path in the test file for the `create-element-to-jsx` codemod in the `react` category. The incorrect path caused test failures and inconsistencies during execution. The updated import path ensures the tests function correctly and reference the intended module.

---

#### 🧪 Test Plan

1. Run the tests for the `create-element-to-jsx` codemod:  
   ```bash
   npm test
   ```
2. Confirm that all tests pass without errors.
3. Verify that the import path in the test file now correctly references the target module.
