### PR TITLE
fix(codemods/netlify-sdk/0.8.5/deleteEnvironmentVariable): remove test script from package.json in deleteEnvironmentVariable codemod

### DIFF
--- a/codemods/netlify-sdk/0.8.5/deleteEnvironmentVariable/package.json
+++ b/codemods/netlify-sdk/0.8.5/deleteEnvironmentVariable/package.json
@@ -13,8 +13,6 @@
   "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
-    "test": "vitest run",
-    "test:watch": "vitest watch",
     "coverage": "vitest run --coverage"
   },
   "files": [


### PR DESCRIPTION
#### 📚 Description

This PR removes the `test` script from the `package.json` file in the `deleteEnvironmentVariable` codemod under `netlify-sdk/0.8.5`. The script was unnecessary, and its removal ensured a cleaner configuration for the codemod.

---

#### 🧪 Test Plan

1. Verify that the `test` script has been removed from the `package.json` file.  
2. Ensure all related processes or workflows are unaffected by the removal.  
