### PR TITLE
fix(tooling/workflow): remove test script from package.json in workflow

### DIFF
--- a/tooling/workflow/package.json
+++ b/tooling/workflow/package.json
@@ -17,8 +17,6 @@
   ],
   "scripts": {
     "build": "tsc && node ./build.js",
-    "test": "vitest run",
-    "coverage": "vitest run --coverage",
     "prepublish": "cp package.json package.json.bak && jq 'del(.devDependencies)' package.json.bak > package.json",
     "postpublish": "rm package.json && mv package.json.bak package.json"
   },


### PR DESCRIPTION
#### 📚 Description

This PR removes the `test` script from the `package.json` file in the `tooling/workflow` directory. The script was unnecessary, and its removal ensures a cleaner and more accurate package configuration.

---

#### 🧪 Test Plan

1. Verify that the `test` script has been removed from the `package.json` file.  
2. Confirm all workflows and processes function correctly without the `test` script.  