### PR TITLE
refactor(codemods/react/prop-types-typescript): replace @ts-expect-error with explicit any annotations

### DIFF
--- a/codemods/react/prop-types-typescript/.codemodrc.json
+++ b/codemods/react/prop-types-typescript/.codemodrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": false,
   "name": "react/prop-types-typescript",
   "description": "Codemod to convert React PropTypes to TypeScript types.",

--- a/codemods/react/prop-types-typescript/.codemodrc.json
+++ b/codemods/react/prop-types-typescript/.codemodrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": false,
   "name": "react/prop-types-typescript",
   "description": "Codemod to convert React PropTypes to TypeScript types.",

--- a/codemods/react/prop-types-typescript/package.json
+++ b/codemods/react/prop-types-typescript/package.json
@@ -8,7 +8,8 @@
     "jscodeshift": "^0.15.1",
     "@types/jscodeshift": "^0.11.10",
     "vitest": "^1.0.1",
-    "@vitest/coverage-v8": "catalog:"
+    "@vitest/coverage-v8": "catalog:",
+    "ast-types": "^0.15.0"
   },
   "private": true,
   "main": "./dist/index.cjs",

--- a/codemods/react/prop-types-typescript/src/index.ts
+++ b/codemods/react/prop-types-typescript/src/index.ts
@@ -81,8 +81,7 @@ function isCustomValidator(path: NodePath) {
 const resolveRequired = (path: NodePath) =>
   isRequired(path) ? path.get("object") : path;
 
-//@ts-expect-error any
-function getTSType(path: NodePath) {
+function getTSType(path: NodePath): any {
   const { value: name } =
     path.get("type").value === "MemberExpression"
       ? path.get("property", "name")
@@ -127,8 +126,7 @@ function getTSType(path: NodePath) {
       return arg.get("type").value !== "ArrayExpression"
         ? j.tsArrayType(j.tsUnknownKeyword())
         : j.tsUnionType(
-            //@ts-expect-error any
-            arg.get("elements").value.map(({ type, value }) => {
+            arg.get("elements").value.map(({ type, value }: { type: any, value: any }) => {
               switch (type) {
                 case "StringLiteral":
                   return j.tsLiteralType(j.stringLiteral(value));
@@ -175,10 +173,9 @@ function getTSType(path: NodePath) {
     object: j.tsObjectKeyword(),
     string: j.tsStringKeyword(),
     symbol: j.tsSymbolKeyword(),
-  };
+  } as const;
 
-  //@ts-expect-error any
-  return map[name] || j.tsUnknownKeyword();
+  return (name in map ? map[name as keyof typeof map] : j.tsUnknownKeyword());
 }
 
 const isRequired = (path: NodePath) =>
@@ -226,8 +223,7 @@ function getTSTypes(
         component: getComponentName(path),
         types: path
           .filter(
-            //@ts-expect-error any
-            ({ value }) => propertyTypes.includes(value.type),
+            ({ value }: { value: any }) => propertyTypes.includes(value.type),
             null,
           )
           .map(mapType, null),
@@ -237,8 +233,7 @@ function getTSTypes(
   return collected;
 }
 
-//@ts-expect-error any
-function getFunctionParent(path: NodePath) {
+function getFunctionParent(path: NodePath): NodePath {
   return path.parent.get("type").value === "Program"
     ? path
     : getFunctionParent(path.parent);

--- a/codemods/react/prop-types-typescript/src/index.ts
+++ b/codemods/react/prop-types-typescript/src/index.ts
@@ -51,7 +51,7 @@ let options: {
   preservePropTypes: "none" | "unconverted" | "all";
 };
 
-function reactType(type: string) {
+function reactType(type: string) { 
   return j.tsQualifiedName(j.identifier("React"), j.identifier(type));
 }
 


### PR DESCRIPTION
#### 📚 Description  
This refactors the `prop-types-typescript` codemod source by replacing `@ts-expect-error` comments with explicit `any` type annotations. This change makes type assignments more explicit, reducing reliance on suppression comments while maintaining functionality.  

#### 🧪 Test Plan  
- Run `npm run test` to verify that the codemod works correctly.  
