### PR TITLE
fix: webpack/v5/json-imports-to-default-import - Refactored codemod to remove deprecated behavior and improved Test Coverage

### DIFF
--- a/codemods/webpack/v5/json-imports-to-default-imports/.codemodrc.json
+++ b/codemods/webpack/v5/json-imports-to-default-imports/.codemodrc.json
@@ -2,7 +2,7 @@
   "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
   "name": "webpack/v5/json-imports-to-default-imports",
   "description": "This codemod migrates imports from JSON modules that use named exports to use default exports instead",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "engine": "jscodeshift",
   "private": false,
   "applicability": {

--- a/codemods/webpack/v5/json-imports-to-default-imports/README.md
+++ b/codemods/webpack/v5/json-imports-to-default-imports/README.md
@@ -1,6 +1,6 @@
 This codemod migrates imports from JSON modules that use named exports to use default exports instead.
 
-It replaces code like `import { version } from './package.json'; console.log(version);` with `import pkg from './package.json'; console.log(pkg.version);`.
+This codemod transforms named imports from JSON files into default imports, adhering to the new ECMAScript specification and Webpack v5 compatibility. Named imports from JSON modules are no longer supported.
 
 ## Example
 
@@ -16,36 +16,4 @@ console.log(version);
 ```ts
 import pkg from "./package.json";
 console.log(pkg.version);
-```
-
-,
-
-### Before
-
-```ts
-import { version, name, description } from "./package.json";
-console.log(version, name, description);
-```
-
-### After
-
-```ts
-import pkg from "./package.json";
-console.log(pkg.version, pkg.name, pkg.description);
-```
-
-,
-
-### Before
-
-```ts
-import { nested, nested2 } from "./data.json";
-console.log(nested.property, nested2.property);
-```
-
-### After
-
-```ts
-import pkg from "./data.json";
-console.log(pkg.nested.property, pkg.nested2.property);
 ```

--- a/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture1.output.ts
+++ b/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture1.output.ts
@@ -1,2 +1,2 @@
-import pkg from './package.json';
+import pkg from "./package.json";
 console.log(pkg.version);

--- a/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture2.input.ts
+++ b/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture2.input.ts
@@ -1,2 +1,2 @@
-import { version, name, description } from "./package.json";
-console.log(version, name, description);
+import { data } from './config.json';
+console.log(data.nested.key, data.anotherKey);

--- a/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture2.output.ts
+++ b/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture2.output.ts
@@ -1,2 +1,2 @@
-import pkg from './package.json';
-console.log(pkg.version, pkg.name, pkg.description);
+import config from './config.json';
+console.log(config.data.nested.key, config.data.anotherKey);

--- a/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture3.input.ts
+++ b/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture3.input.ts
@@ -1,2 +1,2 @@
-import { nested, nested2 } from "./data.json";
-console.log(nested.property, nested2.property);
+import config from './config.json';
+console.log(config.key, config.nested.value);

--- a/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture3.output.ts
+++ b/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture3.output.ts
@@ -1,2 +1,2 @@
-import pkg from './data.json';
-console.log(pkg.nested.property, pkg.nested2.property);
+import config from './config.json';
+console.log(config.key, config.nested.value);

--- a/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture4.input.ts
+++ b/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture4.input.ts
@@ -1,0 +1,2 @@
+import { key1, key2 } from './config.json';
+console.log(key1, key2);

--- a/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture4.output.ts
+++ b/codemods/webpack/v5/json-imports-to-default-imports/__testfixtures__/fixture4.output.ts
@@ -1,0 +1,2 @@
+import config from './config.json';
+console.log(config.key1, config.key2);

--- a/codemods/webpack/v5/json-imports-to-default-imports/src/index.ts
+++ b/codemods/webpack/v5/json-imports-to-default-imports/src/index.ts
@@ -1,21 +1,32 @@
 export default function transform(file, api, options) {
   const j = api.jscodeshift;
   const root = j(file.source);
-  let dirtyFlag = false;
+  let hasModified = false;
+
+  // Determine the original quote style
+  const originalQuoteStyle = file.source.includes("'") ? 'single' : 'double';
 
   // Find all import declarations
   root.find(j.ImportDeclaration).forEach((path) => {
     const importPath = path.node.source.value;
 
     // Check if the import is from a JSON file
-    if (importPath.endsWith(".json")) {
+    if (importPath.endsWith('.json')) {
       const specifiers = path.node.specifiers;
 
       // Check if there are named imports
-      if (specifiers.some((specifier) => j.ImportSpecifier.check(specifier))) {
-        const defaultImportIdentifier = j.identifier("pkg");
+      if (
+        specifiers.some((specifier) =>
+          j.ImportSpecifier.check(specifier),
+        )
+      ) {
+        // Determine the default import identifier
+        const importBaseName = importPath.split('/').pop().replace('.json', '');
+        const defaultImportName =
+          importBaseName === 'package' ? 'pkg' : importBaseName;
+        const defaultImportIdentifier = j.identifier(defaultImportName);
 
-        // Create a new default import declaration with single quotes
+        // Create a new default import declaration with the original quote style
         const newImportDeclaration = j.importDeclaration(
           [j.importDefaultSpecifier(defaultImportIdentifier)],
           j.literal(importPath),
@@ -32,22 +43,47 @@ export default function transform(file, api, options) {
 
             root
               .find(j.Identifier, { name: localName })
-              .forEach((identifierPath) => {
-                j(identifierPath).replaceWith(
-                  j.memberExpression(
-                    defaultImportIdentifier,
-                    j.identifier(importedName),
-                  ),
+              .filter((idPath) => {
+                // Exclude identifiers used in import declarations
+                const parent = idPath.parent.node;
+                return (
+                  !j.ImportDeclaration.check(parent) &&
+                  !j.ImportSpecifier.check(parent) &&
+                  !j.ImportDefaultSpecifier.check(parent) &&
+                  !j.ImportNamespaceSpecifier.check(parent)
                 );
+              })
+              .forEach((identifierPath) => {
+                const parent = identifierPath.parent.node;
+
+                if (
+                  j.MemberExpression.check(parent) &&
+                  parent.object === identifierPath.node
+                ) {
+                  j(identifierPath).replaceWith(
+                    j.memberExpression(
+                      defaultImportIdentifier,
+                      j.identifier(importedName)
+                    )
+                  );
+                } else {
+                  j(identifierPath).replaceWith(
+                    j.memberExpression(
+                      defaultImportIdentifier,
+                      j.identifier(importedName)
+                    )
+                  );
+                }
               });
           }
         });
 
-        dirtyFlag = true;
+        hasModified = true;
       }
     }
   });
 
-  // Use 'single' quotes in the final output
-  return dirtyFlag ? root.toSource({ quote: "single" }) : undefined;
+  return hasModified
+    ? root.toSource({ quote: originalQuoteStyle })
+    : file.source;
 }

--- a/codemods/webpack/v5/json-imports-to-default-imports/test/test.ts
+++ b/codemods/webpack/v5/json-imports-to-default-imports/test/test.ts
@@ -21,7 +21,11 @@ const buildApi = (parser: string | undefined): API => ({
 });
 
 describe("json-imports-to-default-imports", () => {
-  it("test #1", async () => {
+   /**
+   * Test Case 1: Basic Named Import Transformation
+   * This test validates that named imports from JSON files
+   */
+  it("test #1 - Basic Named Import Transformation", async () => {
     const INPUT = await readFile(
       join(__dirname, "..", "__testfixtures__/fixture1.input.ts"),
       "utf-8",
@@ -46,7 +50,12 @@ describe("json-imports-to-default-imports", () => {
     );
   });
 
-  it("test #2", async () => {
+  /**
+   * Test Case 2: Nested References Transformation
+   * This test validates that named imports with nested references
+   */
+
+  it("test #2 - Named Import with Nested References", async () => {
     const INPUT = await readFile(
       join(__dirname, "..", "__testfixtures__/fixture2.input.ts"),
       "utf-8",
@@ -71,13 +80,40 @@ describe("json-imports-to-default-imports", () => {
     );
   });
 
-  it("test #3", async () => {
+  // Test Case 3: No Change for Default Import
+  it("test #3 - No Change for Default Import", async () => {
     const INPUT = await readFile(
       join(__dirname, "..", "__testfixtures__/fixture3.input.ts"),
       "utf-8",
     );
     const OUTPUT = await readFile(
       join(__dirname, "..", "__testfixtures__/fixture3.output.ts"),
+      "utf-8",
+    );
+
+    const actualOutput = transform(
+      {
+        path: "index.js",
+        source: INPUT,
+      },
+      buildApi("tsx"),
+      {},
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ""),
+      OUTPUT.replace(/W/gm, ""),
+    );
+  });
+
+  // Test Case 4: Multiple Named Imports
+  it("test #4 - Multiple Named Imports", async () => {
+    const INPUT = await readFile(
+      join(__dirname, "..", "__testfixtures__/fixture4.input.ts"),
+      "utf-8",
+    );
+    const OUTPUT = await readFile(
+      join(__dirname, "..", "__testfixtures__/fixture4.output.ts"),
       "utf-8",
     );
 


### PR DESCRIPTION

<!--
THANK YOU for contributing to Codemod Commons! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description

<!--
A summary of the change. Include relevant motivation and context.
-->


This PR refactors the `json-imports-to-default-imports` codemod to improve its functionality and test coverage. The following changes have been made:
- **Removed Deprecated Behavior**: The codemod now handles files with extra content (e.g., code outside import lines) seamlessly.
- **Improved Nested Reference Handling**: Properly transforms nested references for named imports.
- **Enhanced Test Coverage**: Added multiple test cases to cover various scenarios, including basic transformations, nested references, default imports, and multiple named imports.


#### 🔗 Linked Issue

<!--
For trivial changes, this can be removed. For non-trivial changes, link to an issue that includes the impact, priority, effort, and more context and discussions. Mention its number here. For example:
- Fixes #XXXX (GitHub issue number for community contributions)
-->

#### 🧪 Test Plan

<!--
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->


The following test cases have been added:

1. **Test Case 1 - Basic Named Import Transformation**:
   Validates that named imports from JSON files (e.g., `import { version } from './package.json';`) are correctly transformed into default imports (e.g., `import pkg from './package.json';`).

2. **Test Case 2 - Nested References Transformation**:
   Verifies that named imports with nested references (e.g., `data.nested.key`) are transformed into default imports with proper nested property access.

3. **Test Case 3 - No Change for Default Import**:
   Ensures that default imports remain unchanged.

4. **Test Case 4 - Multiple Named Imports**:
   Validates that multiple named imports from a single JSON file are transformed into the appropriate default import with proper property mapping.


#### 📄 Documentation to Update

<!--
Please identify the existing or missing docs for your feature and update or create them if needed.
-->
